### PR TITLE
Converted _hidetraceback to decorator

### DIFF
--- a/expecter/__init__.py
+++ b/expecter/__init__.py
@@ -10,6 +10,7 @@ import os
 import pprint
 import sys
 from collections import OrderedDict
+from functools import wraps
 from importlib.metadata import PackageNotFoundError, version
 
 
@@ -20,6 +21,14 @@ except PackageNotFoundError:
 
 
 __all__ = ['expect']
+
+
+def _hidetraceback(f):
+    @wraps(f)
+    def _(*args, **kwargs):
+        f.__globals__['__tracebackhide__'] = os.getenv('EXPECTER_HIDETRACEBACK')
+        return f(*args, **kwargs)
+    return _
 
 
 class Anything:
@@ -68,9 +77,9 @@ class expect:
             predicate = _custom_expectations[name]
             return _CustomExpectation(predicate, self._actual)
         return getattr(super(), name)
-
+    
+    @_hidetraceback
     def __eq__(self, other):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         msg = 'Expected %s but got %s' % (repr(other), repr(self._actual))
         if isinstance(other, str) and isinstance(self._actual, str):
             msg += normalized_diff(other, self._actual)
@@ -78,40 +87,40 @@ class expect:
             msg += normalized_diff(pprint.pformat(other), pprint.pformat(self._actual))
         assert self._actual == other, msg
         return self
-
+    
+    @_hidetraceback
     def __ne__(self, other):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         assert self._actual != other, 'Expected anything except %s but got it' % repr(
             self._actual
         )
         return self
 
+    @_hidetraceback
     def __lt__(self, other):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         assert self._actual < other, 'Expected something less than %s but got %s' % (
             repr(other),
             repr(self._actual),
         )
         return self
 
+    @_hidetraceback
     def __gt__(self, other):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         assert self._actual > other, 'Expected something greater than %s but got %s' % (
             repr(other),
             repr(self._actual),
         )
         return self
 
+    @_hidetraceback
     def __le__(self, other):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         assert self._actual <= other, (
             'Expected something less than or equal to %s but got %s'
             % (repr(other), repr(self._actual))
         )
         return self
 
+    @_hidetraceback
     def __ge__(self, other):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         assert self._actual >= other, (
             'Expected something greater than or equal to %s but got %s'
             % (repr(other), repr(self._actual))
@@ -121,9 +130,9 @@ class expect:
     def __repr__(self):
         return 'expect(%s)' % repr(self._actual)
 
+    @_hidetraceback
     def is_(self, other):
         """Ensure that ``other`` is identical to the actual value."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         label = 'condition' if isinstance(self._actual, bool) else 'value'
         assert self._actual is other, "Expected %s to be %s, but it was %s" % (
             label,
@@ -132,9 +141,9 @@ class expect:
         )
         return self
 
+    @_hidetraceback
     def is_not(self, other):
         """Ensure that ``other`` is not identical to the actual value."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         label = 'condition' if isinstance(self._actual, bool) else 'value'
         assert self._actual is not other, "Expected %s to not be %s, but it was" % (
             label,
@@ -142,12 +151,12 @@ class expect:
         )
         return self
 
+    @_hidetraceback
     def isinstance(self, expected_cls):
         """Ensure the actual value is of type ``expected_cls``.
 
         This is similar to ``assert isinstance(actual, MyClass)``.
         """
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         if isinstance(expected_cls, tuple):
             cls_name = [c.__name__ for c in expected_cls]
             cls_name = ' or '.join(cls_name)  # type: ignore
@@ -158,13 +167,12 @@ class expect:
             % (cls_name, self._actual.__class__.__name__)
         )
 
+    @_hidetraceback
     def contains(self, other):
         """Ensure that ``other`` is in the actual value.
 
         This is similar to ``assert other in actual``.
         """
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = "Given text:\n\n%s\n\nExpected to contain %s but didn't" % (
                 self._actual.strip(),
@@ -178,10 +186,9 @@ class expect:
 
         assert other in self._actual, msg
 
+    @_hidetraceback
     def icontains(self, other):
         """Same as ``contains` but ignoring case."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = (
                 "Given text:\n\n%s\n\nExpected to contain %s (ignoring case) but didn't"
@@ -198,10 +205,9 @@ class expect:
 
         assert expected in actual, msg
 
+    @_hidetraceback
     def includes(self, other):
         """Same as ``contains`` but with alternate phrasing."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = "Given text:\n\n%s\n\nExpected to include %s but didn't" % (
                 self._actual.strip(),
@@ -215,10 +221,9 @@ class expect:
 
         assert other in self._actual, msg
 
+    @_hidetraceback
     def does_not_contain(self, other):
         """Opposite of ``contains``."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = "Given text:\n\n%s\n\nExpected not to contain %s but did" % (
                 self._actual.strip(),
@@ -232,10 +237,9 @@ class expect:
 
         assert other not in self._actual, msg
 
+    @_hidetraceback
     def excludes(self, other):
         """Opposite of ``contains`` with alternate phrasing."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = "Given text:\n\n%s\n\nExpected to exclude %s but didn't" % (
                 self._actual.strip(),
@@ -249,10 +253,9 @@ class expect:
 
         assert other not in self._actual, msg
 
+    @_hidetraceback
     def iexcludes(self, other):
         """Same as ``excludes`` but ignoring case."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = (
                 "Given text:\n\n%s\n\nExpected to exclude %s (ignoring case) but didn't"
@@ -269,10 +272,9 @@ class expect:
 
         assert expected not in actual, msg
 
+    @_hidetraceback
     def startswith(self, other):
         """Ensure that ``other`` starts the actual value."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = "Given text:\n\n%s\n\nExpected to start with %s but didn't" % (
                 self._actual.strip(),
@@ -285,11 +287,10 @@ class expect:
             )
 
         assert self._actual.startswith(other), msg
-
+    
+    @_hidetraceback
     def istartswith(self, other):
         """Same as ``startswith`` but ignoring case."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = (
                 "Given text:\n\n%s\n\nExpected to start with %s (ignoring case) but didn't"
@@ -303,10 +304,9 @@ class expect:
 
         assert self._actual.lower().startswith(other.lower()), msg
 
+    @_hidetraceback
     def endswith(self, other):
         """Ensure that ``other`` ends the actual value."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = "Given text:\n\n%s\n\nExpected to end with %s but didn't" % (
                 self._actual.strip(),
@@ -320,10 +320,9 @@ class expect:
 
         assert self._actual.endswith(other), msg
 
+    @_hidetraceback
     def iendswith(self, other):
         """Same as ``endswith`` but ignoring case."""
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
-
         if isinstance(self._actual, str) and '\n' in self._actual:
             msg = (
                 "Given text:\n\n%s\n\nExpected to end with %s (ignoring case) but didn't"
@@ -373,8 +372,8 @@ class _RaisesExpectation:
     def __enter__(self):
         pass
 
+    @_hidetraceback
     def __exit__(self, exc_type, exc_value, traceback):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         success = not exc_type
         if success:
             raise AssertionError(
@@ -383,8 +382,8 @@ class _RaisesExpectation:
             )
         return self.validate_failure(exc_type, exc_value)
 
+    @_hidetraceback
     def validate_failure(self, exc_type, exc_value):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         wrong_message_was_raised = self.message and self.message != str(exc_value)
         if wrong_message_was_raised:
             raise AssertionError(
@@ -418,12 +417,12 @@ class _CustomExpectation:
         self._predicate = predicate
         self._actual = actual
 
+    @_hidetraceback
     def __call__(self, *args, **kwargs):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         self.enforce(*args, **kwargs)
 
+    @_hidetraceback
     def enforce(self, *args, **kwargs):
-        __tracebackhide__ = _hidetraceback()  # pylint: disable=unused-variable
         if not self._predicate(self._actual, *args, **kwargs):
             predicate_name = self._predicate.__name__.replace('_', ' ')
             raise AssertionError(
@@ -480,7 +479,3 @@ def normalized_diff(other, actual):
     diff = difflib.unified_diff(other.splitlines(), actual.splitlines(), lineterm='')
     diff = list(diff)  # type: ignore
     return '\n'.join(['\nDiff:'] + diff[2:])  # type: ignore
-
-
-def _hidetraceback():
-    return os.getenv('EXPECTER_HIDETRACEBACK')

--- a/expecter/__init__.py
+++ b/expecter/__init__.py
@@ -28,6 +28,7 @@ def _hidetraceback(f):
     def _(*args, **kwargs):
         f.__globals__['__tracebackhide__'] = os.getenv('EXPECTER_HIDETRACEBACK')
         return f(*args, **kwargs)
+
     return _
 
 
@@ -77,7 +78,7 @@ class expect:
             predicate = _custom_expectations[name]
             return _CustomExpectation(predicate, self._actual)
         return getattr(super(), name)
-    
+
     @_hidetraceback
     def __eq__(self, other):
         msg = 'Expected %s but got %s' % (repr(other), repr(self._actual))
@@ -87,7 +88,7 @@ class expect:
             msg += normalized_diff(pprint.pformat(other), pprint.pformat(self._actual))
         assert self._actual == other, msg
         return self
-    
+
     @_hidetraceback
     def __ne__(self, other):
         assert self._actual != other, 'Expected anything except %s but got it' % repr(
@@ -287,7 +288,7 @@ class expect:
             )
 
         assert self._actual.startswith(other), msg
-    
+
     @_hidetraceback
     def istartswith(self, other):
         """Same as ``startswith`` but ignoring case."""


### PR DESCRIPTION
Converted `_hidetraceback` to decorator and removed `# pylint: disable=unused-variable` comments.